### PR TITLE
Issue 22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.12
 
 # Install Docker
 ENV DOCKER_BUILDKIT="1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/custom_components/incontrol2/__init__.py
+++ b/custom_components/incontrol2/__init__.py
@@ -83,6 +83,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DATA_INCONTROL2] = incontrol2.InControl2Device
 
     hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "binary_sensor")
+    )
+    hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "sensor")
     )
     hass.async_create_task(

--- a/custom_components/incontrol2/binary_sensor.py
+++ b/custom_components/incontrol2/binary_sensor.py
@@ -1,0 +1,167 @@
+"""Support for InControl2 vehicles."""
+
+import logging
+from typing import Callable
+
+from .incontrol2 import InControl2Device
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
+
+from .const import (
+    DOMAIN,
+    PEPLINK,
+    IncontrolIcons
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(_hass: HomeAssistant,
+                            _entry: ConfigEntry,
+                            async_add_entities: Callable[[list, bool], None]):
+    devs = []
+    for device in InControl2Device.get_devices():
+        devs.append(InControl2Vehicle(device, {}))
+
+        for wan in device.wans:
+            devs.append(InControl2WanStatus(wan["id"], wan, device, {}))
+
+    async_add_entities(devs, True)
+
+
+class InControl2Vehicle(BinarySensorEntity):
+
+    def __init__(self, vehicle: InControl2Device, store):
+        """Initialize the sensor."""
+        self._vehicle = vehicle
+        self._store = store
+        self._data = {}
+
+        self._vehicle.add_entity(self)
+        _LOGGER.debug("found device")
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f'{self._vehicle.name} Status'
+
+    async def async_update(self) -> bool:
+        await self._vehicle.update()
+
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        return self._vehicle.state != "online"
+
+    @property
+    def device_class(self):
+        return BinarySensorDeviceClass.PROBLEM
+
+    @property
+    def unique_id(self):
+        return f'{self._vehicle.org_id}_{self._vehicle.group_id}_{self._vehicle.device_id}'
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.unique_id)
+            },
+            "name": self._vehicle.data.get("name"),
+            "manufacturer": PEPLINK,
+            "model": self._vehicle.data.get("product_name"),
+            "sw_version": self._vehicle.data.get("fw_ver "),
+        }
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the vehicle."""
+        return self._vehicle.data
+
+
+class InControl2WanStatus(BinarySensorEntity):
+
+    def __init__(self, wan_id, wan, vehicle, store):
+        """Initialize the sensor."""
+        self._wan_id = wan_id
+        self._wan = wan
+        self._vehicle = vehicle
+        self._store = store
+        self._data = {}
+
+        self._vehicle.add_entity(self)
+        _LOGGER.debug("found wan device")
+
+    async def async_update(self) -> bool:
+        await self._vehicle.update()
+
+        wan = next((wan for wan in self._vehicle.wans if wan.get(
+            'id') == self._wan_id), None)
+
+        if wan is None:
+            _LOGGER.debug(f"WAN id {self._wan_id} not found in update")
+            return False
+
+        _LOGGER.debug(f"WAN id {self._wan_id} updated: {wan}")
+
+        self._wan = wan
+
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f'{self._vehicle.name} {self.wan_name} Status'
+
+    @property
+    def wan_name(self):
+        return self._wan.get('name')
+
+    @property
+    def is_connected(self):
+        status = self._wan.get("status")
+        return "Connected" in status
+
+    @property
+    def device_id(self):
+        return f'{self._vehicle.org_id}_{self._vehicle.group_id}_{self._vehicle.device_id}'
+
+    @property
+    def unique_id(self):
+        return f'{self._vehicle.org_id}_{self._vehicle.group_id}_{self._vehicle.device_id}_wan_status_{self._wan_id}'
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.device_id)
+            },
+            "name": self._vehicle.data.get("name"),
+            "manufacturer": PEPLINK,
+            "model": self._vehicle.data.get("product_name"),
+            "sw_version": self._vehicle.data.get("fw_ver "),
+        }
+
+    @property
+    def device_class(self):
+        return BinarySensorDeviceClass.CONNECTIVITY
+
+    @property
+    def state_attributes(self):
+        return self._wan
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return if the sensor is on or off."""
+        if "Connected" in self._wan.get('status'):
+            return True
+        else:
+            return False
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        return self._wan.get("is_enable") == 1

--- a/custom_components/incontrol2/binary_sensor.py
+++ b/custom_components/incontrol2/binary_sensor.py
@@ -39,7 +39,6 @@ class InControl2Vehicle(BinarySensorEntity):
         self._data = {}
 
         self._vehicle.add_entity(self)
-        _LOGGER.debug("found device")
 
     @property
     def name(self):
@@ -93,7 +92,6 @@ class InControl2WanStatus(BinarySensorEntity):
         self._data = {}
 
         self._vehicle.add_entity(self)
-        _LOGGER.debug("found wan device")
 
     async def async_update(self) -> bool:
         await self._vehicle.update()

--- a/custom_components/incontrol2/const.py
+++ b/custom_components/incontrol2/const.py
@@ -8,6 +8,35 @@ STORAGE_KEY = "incontrol2_auth"
 STORAGE_VERSION = 1
 DATA_INCONTROL2 = "incontrol2"
 
+PEPLINK = "PepLink"
+SIGNAL_UNITS = "dB"
+
 AUTH_CALLBACK_NAME = "api:incontrol2"
 AUTH_CALLBACK_PATH = "/api/incontrol2"
 INCONTROL_URL = "https://incontrol2.peplink.com/"
+
+
+class IncontrolIcons(object):
+    ETHERNET_CONNECTED = "mdi:ethernet"
+    ETHERNET_DISCONNECTED = "mdi:ethernet-off"
+    WIFI_CONNECTED = "mdi:wifi-strength-outline"
+    WIFI_DISCONNECTED = "mdi:wifi-strength-off-outline"
+    WIFI_STRENGTH = [
+        'mdi:wifi-strength-off-outline',
+        'mdi:wifi-strength-outline',
+        'mdi:wifi-strength-1',
+        'mdi:wifi-strength-2',
+        'mdi:wifi-strength-3',
+        'mdi:wifi-strength-4'
+    ]
+    CELLULAR_CONNECTED = "mdi:network-strength-outline"
+    CELLULAR_DISCONNECTED = "mdi:network-strength-off-outline"
+    CELLULAR_STRENGTH = [
+        'mdi:network-strength-off-outline',
+        'mdi:network-strength-outline',
+        'mdi:network-strength-1',
+        'mdi:network-strength-2',
+        'mdi:network-strength-3',
+        'mdi:network-strength-4',
+    ]
+    SIGNAL_DEFAULT = "mdi:wifi-strength-alert-outline"

--- a/custom_components/incontrol2/device_tracker.py
+++ b/custom_components/incontrol2/device_tracker.py
@@ -41,6 +41,7 @@ class InControl2DeviceTracker(TrackerEntity, RestoreEntity):
         self._state = 'offline'
 
         self._vehicle.add_entity(self)
+        _LOGGER.debug("found device_tracker device")
 
     async def async_update(self) -> bool:
         await self._vehicle.update()

--- a/custom_components/incontrol2/device_tracker.py
+++ b/custom_components/incontrol2/device_tracker.py
@@ -41,7 +41,6 @@ class InControl2DeviceTracker(TrackerEntity, RestoreEntity):
         self._state = 'offline'
 
         self._vehicle.add_entity(self)
-        _LOGGER.debug("found device_tracker device")
 
     async def async_update(self) -> bool:
         await self._vehicle.update()

--- a/custom_components/incontrol2/sensor.py
+++ b/custom_components/incontrol2/sensor.py
@@ -44,7 +44,6 @@ class InControl2Wan(SensorEntity):
         self._data = {}
 
         self._vehicle.add_entity(self)
-        _LOGGER.debug("found wan device")
 
     async def async_update(self) -> bool:
         await self._vehicle.update()

--- a/custom_components/incontrol2/sensor.py
+++ b/custom_components/incontrol2/sensor.py
@@ -120,6 +120,9 @@ class InControl2Wan(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
+        if self._wan.get("type") == "ethernet":
+            return self._wan.get("status")
+
         return self._wan.get("signal")
 
     @property
@@ -130,8 +133,17 @@ class InControl2Wan(Entity):
             'mdi:network-strength-1',
             'mdi:network-strength-2',
             'mdi:network-strength-3',
-            'mdi:network-strength-4'
+            'mdi:network-strength-4',
+            'mdi:ethernet',
+            'mdi:ethernet-off'
         ]
+
+        if self._wan.get("type") == "ethernet":
+            status = self._wan.get("status")
+            if "Connected" in status:
+                return icons[6]
+            else:
+                return icons[7]
 
         signal_bars = self._wan.get("signal_bar", 0)
 

--- a/custom_components/incontrol2/sensor.py
+++ b/custom_components/incontrol2/sensor.py
@@ -44,6 +44,11 @@ class InControl2Vehicle(Entity):
     def name(self):
         """Return the name of the sensor."""
         return f'{self._vehicle.name} Status'
+    
+    async def async_update(self) -> bool:
+        await self._vehicle.update()
+
+        return True
 
     @property
     def state(self):
@@ -89,6 +94,19 @@ class InControl2Wan(Entity):
         self._data = {}
 
         self._vehicle.add_entity(self)
+
+    async def async_update(self) -> bool:
+        await self._vehicle.update()
+
+        wan = next((wan for wan in self._vehicle.wans if wan.get('id')==self._wan_id), None)
+
+        if wan is None:
+            _LOGGER.debug(f"WAN id {self._wan_id} not found in update")
+            return False
+        
+        self._wan = wan
+
+        return True
 
     @property
     def name(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiohttp
-homeassistant==2023.7.3
+homeassistant==2024.10.1


### PR DESCRIPTION
# Fixes
* Fixes #22 by adding missing `async_update` method to WAN entities

# Features
* Creates more appropriate binary_sensor entities for WAN interfaces to track their status
* Creates a "problem" binary_sensor to track if the device is offline or not

# Break Changes
* The overall device status entity is changed from a `sensor` to a `binary_sensor` which more properly reflects the usage as it's really only binary values (online or offline)
* Not really breaking because it could never work but `Signal` entities are no longer created for `ethernet` interfaces